### PR TITLE
Modified util.separate_string to allow lookbehinds in patterns

### DIFF
--- a/reparse/builders.py
+++ b/reparse/builders.py
@@ -107,7 +107,7 @@ class Expression_Builder(object):
 
 def build_pattern(pattern_name, pattern_regex, expression_builder, function_builder):
     final_function = function_builder.get_function(pattern_name, "pattern")
-    inbetweens, expression_names = separate_string(pattern_regex, "<", ">")
+    inbetweens, expression_names = separate_string(pattern_regex)
     expressions = []
     for name in expression_names:
         expression = expression_builder.get_type(name)

--- a/reparse/util.py
+++ b/reparse/util.py
@@ -1,9 +1,11 @@
-def separate_string(string, start_delimiter, end_delimiter):
+import regex
+
+def separate_string(string):
     """
-    >>> separate_string("test (2)", "(", ")")
+    >>> separate_string("test <2>")
     (['test ', ''], ['2'])
     """
-    string_list = string.replace(end_delimiter, start_delimiter).split(start_delimiter)
+    string_list = regex.split(r'<(?![!=])', regex.sub(r'>', '<', string))
     return string_list[::2], string_list[1::2]  # Returns even and odd elements
 
 


### PR DESCRIPTION
Previously, the use of '<' and '>' to denote sub-patterns and expressions prevented a user from putting any kind of lookbehind assertion into a pattern.  Lookbehinds are denoted by '(?<' followed by either '=' or '!' for positive or negative lookbehinds, respectively.  This commit modifies the separate_string function to ignore '<' characters followed by '!' or '=' when splitting the string, allowing you to put lookbehind assertions directly into a pattern.  Note that this will prevent you from naming a pattern or expression with an exclamation mark or equals sign at the beginning, but you probably shouldn't be doing that anyway.
