### PR TITLE
Unicode flag compatibility for python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.4
 install:
   - pip install --use-mirrors pyyaml
-  - pip install --use-mirrors -r requirements.txt
-script: nosetests --with-doctest
+  - pip install --use-mirrors -r requirements-dev.txt
+script: nosetests
 notifications:
   email: false

--- a/examples/colortime/colortime.py
+++ b/examples/colortime/colortime.py
@@ -1,11 +1,12 @@
+from __future__ import unicode_literals
 """ Example from docs:
 
->>> colortime_parser("~ ~ ~ go to the store ~ buy green at 11pm! ~ ~")
+>>> colortime_parser("~ ~ ~ go to the store ~ buy green at 11pm! ~ ~")  # doctest: +IGNORE_UNICODE
 [('green', datetime.time(23, 0))]
 
 In this case the processing functions weren't specified but you
 still get a useful result as a default.
->>> colortime_parser("~ ~ ~ Crazy 2pm green ~ ~")
+>>> colortime_parser("~ ~ ~ Crazy 2pm green ~ ~")  # doctest: +IGNORE_UNICODE
 [['green']]
 """
 # Example stuff -----------------------------------------------------

--- a/examples/phone/phone.py
+++ b/examples/phone/phone.py
@@ -1,7 +1,8 @@
+from __future__ import unicode_literals
 """ Example of a phone number parser
->>> phone_parser('+974-584-5656')
+>>> phone_parser('+974-584-5656')  # doctest: +IGNORE_UNICODE
 [phone(area_code='974', prefix='584', body='5656', fax=False)]
->>> phone_parser('Fax: +974-584-5656')
+>>> phone_parser('Fax: +974-584-5656')  # doctest: +IGNORE_UNICODE
 [phone(area_code='974', prefix='584', body='5656', fax=True)]
 """
 # Example stuff -----------------------------------------------------

--- a/reparse/builders.py
+++ b/reparse/builders.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from reparse.config import pattern_max_recursion_depth
 from reparse.expression import Group, AlternatesGroup, Expression
 from reparse.util import separate_string
@@ -55,7 +56,7 @@ class Function_Builder(object):
             def func(_):
                 if any(_):
                     return _
-        func.__name__ = name
+        func.__name__ = str(name)
         return func
 
     def add_function(self, name, function):
@@ -76,7 +77,7 @@ class Expression_Builder(object):
     >>> function_builder.get_function = get_function
     >>> expression = {'greeting':{'greeting':{'Expression': '(hey)|(cool)', 'Groups' : ['greeting', 'cooly']}}}
     >>> eb = Expression_Builder(expression, function_builder)
-    >>> eb.get_type("greeting").findall("hey, cool!")
+    >>> eb.get_type("greeting").findall("hey, cool!")  # doctest: +IGNORE_UNICODE
     [[('hey',), ('',)], [('',), ('cool',)]]
     """
 

--- a/reparse/expression.py
+++ b/reparse/expression.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from reparse.config import expression_compiler
 from functools import reduce
 
@@ -58,16 +59,16 @@ class Expression(object):
         return self.final_function(list(_run(matches)))
 
     def build_full_tree(self):
-        return u'{}|{}({})'.format(sum(self.group_lengths), self.final_function.__name__, u", ".join(self.build_tree()))
+        return '{}|{}({})'.format(sum(self.group_lengths), self.final_function.__name__, ", ".join(self.build_tree()))
 
     def build_tree(self):
         for length, function in zip(self.group_lengths, self.group_functions):
             if function.__name__ == 'run':
-                yield u'{}|{}({})'.format(
-                    length, function.__self__.final_function.__name__, u", ".join(function.__self__.build_tree())
+                yield '{}|{}({})'.format(
+                    length, function.__self__.final_function.__name__, ", ".join(function.__self__.build_tree())
                 )
             else:
-                yield u'{}|{}()'.format(length, function.__name__)
+                yield '{}|{}()'.format(length, function.__name__)
 
     @staticmethod
     def _list_add(output, match):
@@ -96,8 +97,8 @@ def AlternatesGroup(expressions, final_function, name=""):
     >>> from collections import namedtuple
     >>> expr = namedtuple('expr', 'regex group_lengths run')('(1)', [1], None)
     >>> grouping = AlternatesGroup([expr, expr], lambda f: None, 'yeah')
-    >>> print(grouping.regex)
-    (?:(1))|(?:(1))
+    >>> grouping.regex  # doctest: +IGNORE_UNICODE
+    '(?:(1))|(?:(1))'
     >>> grouping.group_lengths
     [1, 1]
     """
@@ -112,7 +113,7 @@ def Group(expressions, final_function, inbetweens, name=""):
     """
     lengths = []
     functions = []
-    regex = u""
+    regex = ""
     i = 0
     for expression in expressions:
         regex += inbetweens[i]

--- a/reparse/expression.py
+++ b/reparse/expression.py
@@ -96,8 +96,8 @@ def AlternatesGroup(expressions, final_function, name=""):
     >>> from collections import namedtuple
     >>> expr = namedtuple('expr', 'regex group_lengths run')('(1)', [1], None)
     >>> grouping = AlternatesGroup([expr, expr], lambda f: None, 'yeah')
-    >>> grouping.regex
-    '(?:(1))|(?:(1))'
+    >>> print(grouping.regex)
+    (?:(1))|(?:(1))
     >>> grouping.group_lengths
     [1, 1]
     """

--- a/reparse/expression.py
+++ b/reparse/expression.py
@@ -58,16 +58,16 @@ class Expression(object):
         return self.final_function(list(_run(matches)))
 
     def build_full_tree(self):
-        return '{}|{}({})'.format(sum(self.group_lengths), self.final_function.__name__, ", ".join(self.build_tree()))
+        return u'{}|{}({})'.format(sum(self.group_lengths), self.final_function.__name__, u", ".join(self.build_tree()))
 
     def build_tree(self):
         for length, function in zip(self.group_lengths, self.group_functions):
             if function.__name__ == 'run':
-                yield '{}|{}({})'.format(
-                    length, function.__self__.final_function.__name__, ", ".join(function.__self__.build_tree())
+                yield u'{}|{}({})'.format(
+                    length, function.__self__.final_function.__name__, u", ".join(function.__self__.build_tree())
                 )
             else:
-                yield '{}|{}()'.format(length, function.__name__)
+                yield u'{}|{}()'.format(length, function.__name__)
 
     @staticmethod
     def _list_add(output, match):
@@ -112,7 +112,7 @@ def Group(expressions, final_function, inbetweens, name=""):
     """
     lengths = []
     functions = []
-    regex = ""
+    regex = u""
     i = 0
     for expression in expressions:
         regex += inbetweens[i]

--- a/reparse/tools/expression_checker.py
+++ b/reparse/tools/expression_checker.py
@@ -8,12 +8,12 @@ contains assertIn, assertTrue, assertFalse (such as unittest).
 
 Example Usage::
 
-    from reparse.expression_tester import expression_tester
+    from reparse.tools.expression_checker import check_expression
     import unittest
 
-    class cool_test(unittest.Unittest):
+    class cool_test(unittest.TestCase):
         def test_coolness(self):
-            expression_tester(self, load_yaml("parse/cool/expressions.yaml"))
+            check_expression(self, load_yaml("parse/cool/expressions.yaml"))
 """
 from reparse.config import expression_sub
 base_error_msg = u"Expression Type [{}], Group [{}], "

--- a/reparse/tools/expression_checker.py
+++ b/reparse/tools/expression_checker.py
@@ -15,10 +15,11 @@ Example Usage::
         def test_coolness(self):
             check_expression(self, load_yaml("parse/cool/expressions.yaml"))
 """
+from __future__ import unicode_literals
 from reparse.config import expression_sub
-base_error_msg = u"Expression Type [{}], Group [{}], "
-match_error_msg = base_error_msg + u"Could not match [{}]"
-non_match_error_msg = base_error_msg + u"Should not match [{}]"
+base_error_msg = "Expression Type [{}], Group [{}], "
+match_error_msg = base_error_msg + "Could not match [{}]"
+non_match_error_msg = base_error_msg + "Should not match [{}]"
 
 
 def check_expression(testing_framework, expression_dict):

--- a/reparse/tools/expression_checker.py
+++ b/reparse/tools/expression_checker.py
@@ -16,9 +16,9 @@ Example Usage::
             expression_tester(self, load_yaml("parse/cool/expressions.yaml"))
 """
 from reparse.config import expression_sub
-base_error_msg = "Expression Type [{}], Group [{}], "
-match_error_msg = base_error_msg + "Could not match [{}]"
-non_match_error_msg = base_error_msg + "Should not match [{}]"
+base_error_msg = u"Expression Type [{}], Group [{}], "
+match_error_msg = base_error_msg + u"Could not match [{}]"
+non_match_error_msg = base_error_msg + u"Should not match [{}]"
 
 
 def check_expression(testing_framework, expression_dict):

--- a/reparse/validators.py
+++ b/reparse/validators.py
@@ -1,6 +1,6 @@
 # Validators
-pattern_key_error = "Pattern [{}] does not contain the 'Pattern' key"
-expression_key_error = "Expression Type [{}] Expression [{}] does not contain the 'Expression' key"
+pattern_key_error = u"Pattern [{}] does not contain the 'Pattern' key"
+expression_key_error = u"Expression Type [{}] Expression [{}] does not contain the 'Expression' key"
 
 
 def valid_patterns_dict(patterns_dict):

--- a/reparse/validators.py
+++ b/reparse/validators.py
@@ -1,6 +1,8 @@
+from __future__ import unicode_literals
+
 # Validators
-pattern_key_error = u"Pattern [{}] does not contain the 'Pattern' key"
-expression_key_error = u"Expression Type [{}] Expression [{}] does not contain the 'Expression' key"
+pattern_key_error = "Pattern [{}] does not contain the 'Pattern' key"
+expression_key_error = "Expression Type [{}] Expression [{}] does not contain the 'Expression' key"
 
 
 def valid_patterns_dict(patterns_dict):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+nose
+doctest-ignore-unicode

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[nosetests]
+with-doctest=1
+with-doctest-ignore-unicode=1


### PR DESCRIPTION
It is possible to set custom regex flags in the config via monkeypatching.
With python 2.7, however, use of the unicode flag is problematic due to literal bytestrings in the code. By explicitly declaring these string literals as unicode, we get the same behavior in python 2 & 3.

I also updated the docstring example for `expression_checker`.
