### PR TITLE
Easier custom regex flags and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
   - 3.5

--- a/reparse/config.py
+++ b/reparse/config.py
@@ -6,5 +6,9 @@ pattern_max_recursion_depth = 10
 
 # The regex engine and settings
 regex_flags = regex.VERBOSE | regex.IGNORECASE
-expression_compiler = lambda expression: regex.compile(expression, flags=regex_flags)
-expression_sub = lambda expression, sub, string: regex.sub(expression, sub, string, flags=regex_flags)
+
+def get_expression_compiler():
+    return lambda expression: regex.compile(expression, flags=regex_flags)
+    
+def get_expression_sub(): 
+    return lambda expression, sub, string: regex.sub(expression, sub, string, flags=regex_flags)

--- a/reparse/expression.py
+++ b/reparse/expression.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import regex
-
-from reparse.config import expression_compiler
+from past.builtins import basestring
+from reparse.config import get_expression_compiler
 
 
 class Expression(object):
@@ -34,12 +34,13 @@ class Expression(object):
         self.final_function = final_function
         self.name = name
         self.compiled = False
+        self.expression_compiler = get_expression_compiler()
 
     @property
     def pattern(self):
         if not self.compiled:
             try:
-                self.compiled = expression_compiler(self.regex)
+                self.compiled = self.expression_compiler(self.regex)
             except regex.error as e:
                 raise self.InvalidPattern(self.regex, e)
         return self.compiled
@@ -49,7 +50,7 @@ class Expression(object):
         """
         output = []
         for match in self.pattern.findall(string):
-            if isinstance(match, str):
+            if isinstance(match, basestring):
                 match = [match]
             self._list_add(output, self.run(match))
         return output

--- a/reparse/tools/expression_checker.py
+++ b/reparse/tools/expression_checker.py
@@ -16,7 +16,7 @@ Example Usage::
             check_expression(self, load_yaml("parse/cool/expressions.yaml"))
 """
 from __future__ import unicode_literals
-from reparse.config import expression_sub
+from reparse.config import get_expression_sub
 base_error_msg = "Expression Type [{}], Group [{}], "
 match_error_msg = base_error_msg + "Could not match [{}]"
 non_match_error_msg = base_error_msg + "Should not match [{}]"
@@ -33,6 +33,8 @@ def check_expression(testing_framework, expression_dict):
     >>> check_expression(mock_framework(),
     ...   {'class': {'group' :{'Matches': " 0 | 1", 'Non-Matches': "2 | 0 2", 'Expression': "[0-1]"}}})
     """
+    expression_sub = get_expression_sub()
+    
     for expression_type_name, expression_type in expression_dict.items():
         for name, expression_object in expression_type.items():
             if 'Matches' in expression_object.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 regex
+future

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='reparse',
       install_requires=[
           'regex',
           'pyyaml',
+          'future',
       ],
       classifiers=(
           'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,3 @@ commands = nosetests --verbose --with-doctest --with-coverage --cover-package=re
 deps =
     nose
     py{27,33,34,35}: coverage
-    py32: coverage==3.7.1


### PR DESCRIPTION
This adds tests for the use of custom regex flags. While writing the tests, I encountered some problems monkeypatching the config neatly, so I refactored this mechanism.

The tests also uncovered that the type check in `Expression.findall()` was problematic for cross-version compatibility. This could be overcome by using `past.builtins.basestring`, which unfortunately is not compatible with py3.2. Due to the lack of unicode string marker support in py>=3.0,<3.3, it seems practically impossible to maintain support for these versions while allowing custom regex flags.
